### PR TITLE
Support for pydantic 2.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
         language: python
         entry: mypy
         types: [python]
-        additional_dependencies: ["mypy==0.991", "pydantic", "pytest", "types-setuptools"]
+        additional_dependencies: ["mypy==1.4.0", "pydantic", "pytest", "types-setuptools"]
         args: ["--strict", "--install-types", "--non-interactive"]
 
   - repo: local

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ class ExampleConfig(BaseModel):
     password: Optional[str] = Field(description="Password")
     parent_id: Optional[str] = Field(description="Parent ID")
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def check_arguments(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """If one argument is set, they should all be set"""
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="caep",
-    version="0.1.9",
+    version="0.2.0",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",
@@ -25,8 +25,14 @@ setup(
     python_requires=">=3.6, <4",
     package_data={"caep": ["py.typed"]},
     install_requires=[
-        "pydantic>=1.8.0,<2.0.0",
+        "pydantic",
     ],
+    extras_require={
+        "dev": [
+            "mypy",
+            "pytest",
+        ]
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Utilities",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, "README.md"), "rb") as f:
 
 setup(
     name="caep",
-    version="0.2.0",
+    version="1.0.0b1",
     author="mnemonic AS",
     zip_safe=True,
     author_email="opensource@mnemonic.no",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,7 +19,7 @@ class ExampleConfig(BaseModel):
     password: Optional[str] = Field(description="Password")
     parent_id: Optional[str] = Field(description="Parent ID")
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def check_arguments(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """If one argument is set, they should all be set"""
 


### PR DESCRIPTION
This PR includes support for pydantic 2.x, tested with pydantic 2.0b3.

Preliminary testing shows that with these changes, the code should be backward compatible with support for both pydantic 1.x and pydantic 2.x.

Also need to look into why we need to add `skip_on_failure=True`. However, the use of `root_validator` is only used in the example/test and could be migrated to `model_validator` in 2.x.

We should wait until pydantic 2.0 is relased and we have tested this more thoroughly before this is merged.

