### PR TITLE
feat: handle unknown options in ini file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ at load time.
 
 # Change log
 
+## 1.5.0
+
+- Allow options in ini files to have underscores (`_`)
+- Handle unknown options in ini files. As default a warning will be emitted, but this can
+  be configured in `load()` with the `unknown_config_key` option:
+  - `warning`: emit warning (default)
+  - `ignore`: ignore unknown options
+  - `error`: fatal error - raise ValueError and will exit unless `raise_on_validation_error` is `True`
+
 ## 1.3.0
 
 - Use TypeVar in `load` to support typing when loading configuration with a specified module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caep"
-version = "1.4.1"
+version = "1.5.0"
 description = "Config Argument Env Parser (CAEP)"
 authors = [{ name = "mnemonic", email = "opensource@mnemonic.no" }]
 requires-python = ">=3.9"
@@ -25,7 +25,7 @@ dev = [
     "pre-commit>=4.0.0,<5",
     "pre-commit-hooks>=4.6.0,<5",
     "ruff>=0.9,<1",
-    "mypy>=1.15.0,<2",
+    "mypy>=1.16.0,<2",
 ]
 
 [tool.mypy]

--- a/tests/data/config_testdata.ini
+++ b/tests/data/config_testdata.ini
@@ -1,6 +1,7 @@
 [DEFAULT]
 number = 3
 first-file = True
+str_underscore = also from ini
 
 [test]
 enabled = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,6 +14,7 @@ def __argparser() -> argparse.ArgumentParser:
     parser.add_argument("--number", type=int, default=1)
     parser.add_argument("--enabled", action="store_true")
     parser.add_argument("--str-arg")
+    parser.add_argument("--str-underscore")
 
     return parser
 
@@ -41,12 +42,18 @@ def test_argparse_ini() -> None:
     commandline = f"--config {INI_TEST_FILE}".split()
 
     args = config.handle_args(
-        parser, "actworkers", "actworkers.ini", "test", opts=commandline
+        parser,
+        "actworkers",
+        "actworkers.ini",
+        "test",
+        opts=commandline,
+        unknown_config_key="ignore",
     )
 
     assert args.number == 3
     assert args.str_arg == "from ini"
     assert args.enabled is True
+    assert args.str_underscore == "also from ini"
 
 
 def test_argparse_env() -> None:
@@ -92,7 +99,12 @@ def test_argparse_env_ini() -> None:
     commandline = f"--config {INI_TEST_FILE} --str-arg cmdline".split()
 
     args = config.handle_args(
-        parser, "actworkers", "actworkers.ini", "test", opts=commandline
+        parser,
+        "actworkers",
+        "actworkers.ini",
+        "test",
+        opts=commandline,
+        unknown_config_key="ignore",
     )
 
     assert args.number == 4

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 1
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "caep"
-version = "1.3.1"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -33,7 +33,7 @@ requires-dist = [{ name = "pydantic", specifier = ">=1.10.0,<3" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.15.0,<2" },
+    { name = "mypy", specifier = ">=1.16.0,<2" },
     { name = "pre-commit", specifier = ">=4.0.0,<5" },
     { name = "pre-commit-hooks", specifier = ">=4.6.0,<5" },
     { name = "pytest", specifier = ">=8.0.0,<9" },
@@ -105,46 +105,47 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.15.0"
+version = "1.16.1"
 source = { registry = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/simple/" }
 dependencies = [
     { name = "mypy-extensions" },
+    { name = "pathspec" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43" }
+sdist = { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/81/69/92c7fa98112e4d9eb075a239caa4ef4649ad7d441545ccffbd5e34607cbb/mypy-1.16.1.tar.gz", hash = "sha256:6bd00a0a2094841c5e47e7374bb42b83d64c527a502e3334e1173a0c24437bab" }
 wheels = [
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/68/f8/65a7ce8d0e09b6329ad0c8d40330d100ea343bd4dd04c4f8ae26462d0a17/mypy-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:979e4e1a006511dacf628e36fadfecbcc0160a8af6ca7dad2f5025529e082c13" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/b4/95/9c0ecb8eacfe048583706249439ff52105b3f552ea9c4024166c03224270/mypy-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c4bb0e1bd29f7d34efcccd71cf733580191e9a264a2202b0239da95984c5b559" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/84/09/9ec95e982e282e20c0d5407bc65031dfd0f0f8ecc66b69538296e06fcbee/mypy-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be68172e9fd9ad8fb876c6389f16d1c1b5f100ffa779f77b1fb2176fcc9ab95b" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/78/13/f7d14e55865036a1e6a0a69580c240f43bc1f37407fe9235c0d4ef25ffb0/mypy-1.15.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7be1e46525adfa0d97681432ee9fcd61a3964c2446795714699a998d193f1a3" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/48/e1/301a73852d40c241e915ac6d7bcd7fedd47d519246db2d7b86b9d7e7a0cb/mypy-1.15.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2e2c2e6d3593f6451b18588848e66260ff62ccca522dd231cd4dd59b0160668b" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/77/ba/c37bc323ae5fe7f3f15a28e06ab012cd0b7552886118943e90b15af31195/mypy-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:6983aae8b2f653e098edb77f893f7b6aca69f6cffb19b2cc7443f23cce5f4828" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/5a/fa/79cf41a55b682794abe71372151dbbf856e3008f6767057229e6649d294a/mypy-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e601a7fa172c2131bff456bb3ee08a88360760d0d2f8cbd7a75a65497e2df078" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/d3/33/dd8feb2597d648de29e3da0a8bf4e1afbda472964d2a4a0052203a6f3594/mypy-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:712e962a6357634fef20412699a3655c610110e01cdaa6180acec7fc9f8513ba" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/e4/b5/74508959c1b06b96674b364ffeb7ae5802646b32929b7701fc6b18447592/mypy-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f95579473af29ab73a10bada2f9722856792a36ec5af5399b653aa28360290a5" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/6c/53/da61b9d9973efcd6507183fdad96606996191657fe79701b2c818714d573/mypy-1.15.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f8722560a14cde92fdb1e31597760dc35f9f5524cce17836c0d22841830fd5b" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/c1/72/965bd9ee89540c79a25778cc080c7e6ef40aa1eeac4d52cec7eae6eb5228/mypy-1.15.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:1fbb8da62dc352133d7d7ca90ed2fb0e9d42bb1a32724c287d3c76c58cbaa9c2" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/46/d0/f41645c2eb263e6c77ada7d76f894c580c9ddb20d77f0c24d34273a4dab2/mypy-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:d10d994b41fb3497719bbf866f227b3489048ea4bbbb5015357db306249f7980" },
-    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/8e/12/2bf23a80fcef5edb75de9a1e295d778e0f46ea89eb8b115818b663eff42b/mypy-1.16.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b4f0fed1022a63c6fec38f28b7fc77fca47fd490445c69d0a66266c59dd0b88a" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/08/50/bfe47b3b278eacf348291742fd5e6613bbc4b3434b72ce9361896417cfe5/mypy-1.16.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86042bbf9f5a05ea000d3203cf87aa9d0ccf9a01f73f71c58979eb9249f46d72" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/21/de/40307c12fe25675a0776aaa2cdd2879cf30d99eec91b898de00228dc3ab5/mypy-1.16.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ea7469ee5902c95542bea7ee545f7006508c65c8c54b06dc2c92676ce526f3ea" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/a6/d8/85bdb59e4a98b7a31495bd8f1a4445d8ffc86cde4ab1f8c11d247c11aedc/mypy-1.16.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:352025753ef6a83cb9e7f2427319bb7875d1fdda8439d1e23de12ab164179574" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/0e/d0/bb25731158fa8f8ee9e068d3e94fcceb4971fedf1424248496292512afe9/mypy-1.16.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ff9fa5b16e4c1364eb89a4d16bcda9987f05d39604e1e6c35378a2987c1aac2d" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/2d/11/822a9beb7a2b825c0cb06132ca0a5183f8327a5e23ef89717c9474ba0bc6/mypy-1.16.1-cp310-cp310-win_amd64.whl", hash = "sha256:1256688e284632382f8f3b9e2123df7d279f603c561f099758e66dd6ed4e8bd6" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/9a/61/ec1245aa1c325cb7a6c0f8570a2eee3bfc40fa90d19b1267f8e50b5c8645/mypy-1.16.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:472e4e4c100062488ec643f6162dd0d5208e33e2f34544e1fc931372e806c0cc" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/6b/bb/6eccc0ba0aa0c7a87df24e73f0ad34170514abd8162eb0c75fd7128171fb/mypy-1.16.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ea16e2a7d2714277e349e24d19a782a663a34ed60864006e8585db08f8ad1782" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/5f/80/b337a12e2006715f99f529e732c5f6a8c143bb58c92bb142d5ab380963a5/mypy-1.16.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:08e850ea22adc4d8a4014651575567b0318ede51e8e9fe7a68f25391af699507" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/d9/59/f7af072d09793d581a745a25737c7c0a945760036b16aeb620f658a017af/mypy-1.16.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22d76a63a42619bfb90122889b903519149879ddbf2ba4251834727944c8baca" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/82/c4/607672f2d6c0254b94a646cfc45ad589dd71b04aa1f3d642b840f7cce06c/mypy-1.16.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2c7ce0662b6b9dc8f4ed86eb7a5d505ee3298c04b40ec13b30e572c0e5ae17c4" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/b6/5e/136555ec1d80df877a707cebf9081bd3a9f397dedc1ab9750518d87489ec/mypy-1.16.1-cp311-cp311-win_amd64.whl", hash = "sha256:211287e98e05352a2e1d4e8759c5490925a7c784ddc84207f4714822f8cf99b6" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/b4/d6/39482e5fcc724c15bf6280ff5806548c7185e0c090712a3736ed4d07e8b7/mypy-1.16.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:af4792433f09575d9eeca5c63d7d90ca4aeceda9d8355e136f80f8967639183d" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/e6/e5/26c347890efc6b757f4d5bb83f4a0cf5958b8cf49c938ac99b8b72b420a6/mypy-1.16.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:66df38405fd8466ce3517eda1f6640611a0b8e70895e2a9462d1d4323c5eb4b9" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/44/c7/b5cb264c97b86914487d6a24bd8688c0172e37ec0f43e93b9691cae9468b/mypy-1.16.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44e7acddb3c48bd2713994d098729494117803616e116032af192871aed80b79" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/15/f8/491997a9b8a554204f834ed4816bda813aefda31cf873bb099deee3c9a99/mypy-1.16.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ab5eca37b50188163fa7c1b73c685ac66c4e9bdee4a85c9adac0e91d8895e15" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/df/f0/2bd41e174b5fd93bc9de9a28e4fb673113633b8a7f3a607fa4a73595e468/mypy-1.16.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb6229b2c9086247e21a83c309754b9058b438704ad2f6807f0d8227f6ebdd" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/61/81/5572108a7bec2c46b8aff7e9b524f371fe6ab5efb534d38d6b37b5490da8/mypy-1.16.1-cp312-cp312-win_amd64.whl", hash = "sha256:1f0435cf920e287ff68af3d10a118a73f212deb2ce087619eb4e648116d1fe9b" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/28/e3/96964af4a75a949e67df4b95318fe2b7427ac8189bbc3ef28f92a1c5bc56/mypy-1.16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ddc91eb318c8751c69ddb200a5937f1232ee8efb4e64e9f4bc475a33719de438" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/f5/4d/cd1a42b8e5be278fab7010fb289d9307a63e07153f0ae1510a3d7b703193/mypy-1.16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:87ff2c13d58bdc4bbe7dc0dedfe622c0f04e2cb2a492269f3b418df2de05c536" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/c9/4f/c3c6b4b66374b5f68bab07c8cabd63a049ff69796b844bc759a0ca99bb2a/mypy-1.16.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a7cfb0fe29fe5a9841b7c8ee6dffb52382c45acdf68f032145b75620acfbd6f" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/b4/7e/81ca3b074021ad9775e5cb97ebe0089c0f13684b066a750b7dc208438403/mypy-1.16.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:051e1677689c9d9578b9c7f4d206d763f9bbd95723cd1416fad50db49d52f359" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/e9/95/bdd40c8be346fa4c70edb4081d727a54d0a05382d84966869738cfa8a497/mypy-1.16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d5d2309511cc56c021b4b4e462907c2b12f669b2dbeb68300110ec27723971be" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/5a/fd/d486a0827a1c597b3b48b1bdef47228a6e9ee8102ab8c28f944cb83b65dc/mypy-1.16.1-cp313-cp313-win_amd64.whl", hash = "sha256:4f58ac32771341e38a853c5d0ec0dfe27e18e27da9cdb8bbc882d2249c71a3ee" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/49/5e/ed1e6a7344005df11dfd58b0fdd59ce939a0ba9f7ed37754bf20670b74db/mypy-1.16.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7fc688329af6a287567f45cc1cefb9db662defeb14625213a5b7da6e692e2069" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/30/88/a7cbc2541e91fe04f43d9e4577264b260fecedb9bccb64ffb1a34b7e6c22/mypy-1.16.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5e198ab3f55924c03ead626ff424cad1732d0d391478dfbf7bb97b34602395da" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/93/f7/c62b1e31a32fbd1546cca5e0a2e5f181be5761265ad1f2e94f2a306fa906/mypy-1.16.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09aa4f91ada245f0a45dbc47e548fd94e0dd5a8433e0114917dc3b526912a30c" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/c8/15/db580a28034657fb6cb87af2f8996435a5b19d429ea4dcd6e1c73d418e60/mypy-1.16.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13c7cd5b1cb2909aa318a90fd1b7e31f17c50b242953e7dd58345b2a814f6383" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/ec/78/c17f48f6843048fa92d1489d3095e99324f2a8c420f831a04ccc454e2e51/mypy-1.16.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:58e07fb958bc5d752a280da0e890c538f1515b79a65757bbdc54252ba82e0b40" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/bc/d6/ed42167d0a42680381653fd251d877382351e1bd2c6dd8a818764be3beb1/mypy-1.16.1-cp39-cp39-win_amd64.whl", hash = "sha256:f895078594d918f93337a505f8add9bd654d1a24962b4c6ed9390e12531eb31b" },
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/cf/d3/53e684e78e07c1a2bf7105715e5edd09ce951fc3f47cf9ed095ec1b7a037/mypy-1.16.1-py3-none-any.whl", hash = "sha256:5fc2ac4027d0ef28d6ba69a0343737a23c4d1b83672bf38d1fe237bdc0643b37" },
 ]
 
 [[package]]
@@ -172,6 +173,15 @@ source = { registry = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-
 sdist = { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f" }
 wheels = [
     { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759" },
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/simple/" }
+sdist = { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712" }
+wheels = [
+    { url = "http://artifactory.mnemonic.no/artifactory/api/pypi/virt-pypi/packages/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Allow option keys in ini files to have underscores (`_`)
- Handle unknown option keys in ini files. As default a warning will be emitted, but this can be configured in `load()` with the `unknown_config_key` option:
  - `warning`: emit warning (default)
  - `ignore`: ignore unknown option keys
  - `error`: fatal error - raise ValueError and exit unless `raise_on_validation_error` is `True` (same as validation errors)