### PR TITLE
feat: add support to keep unknown arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,20 @@ config = caep.load(
 )
 ```
 
-In this mode, unknown CLI tokens (e.g. `["--other", "value"]`) are stored in
-`config.unknown` while known arguments are parsed as usual. Only one field can be
-marked as unknown-argument.
+In this mode, unknown CLI tokens are stored in `config.unknown` while known arguments are 
+parsed as usual. Only one field can be marked as unknown-argument.
+
+If you run the above script with this command line:
+
+```
+script.py --text hello --other value1 value2
+```
+
+the config object will have these values:
+```
+test: hello
+unknown: ["--other", "value1", "value2"]
+```
 
 # Pydantic field types
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ class Config(BaseModel):
 config = caep.load(
     Config,
     "CAEP Example",
-    unknown_config_key="ignore",  # enables parse_known_args
+    unknown_config_key="ignore",
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ at load time.
 
 # Change log
 
+## 1.6.0
+
+- Add support to retrieve unknown arguments using `json_schema_extra={"caep_unknown_args": True}`
+
 ## 1.5.0
 
 - Allow options in ini files to have underscores (`_`)
@@ -174,6 +178,33 @@ config = caep.load(
 
 With the code above you can still specify an ini file with `--config <ini-file>`, and use
 environment variables and command line arguments.
+
+# Capture unknown command line arguments
+
+You can capture and keep unknown CLI arguments by marking a single field with
+`json_schema_extra={"caep_unknown_args": True}`. This field will receive the raw
+tokens returned by `argparse.parse_known_args` when `unknown_config_key="ignore"`:
+
+```python
+class Config(BaseModel):
+    text: str = Field(description="Required String Argument")
+    unknown: list[str] = Field(
+        default_factory=list,
+        description="Unknown CLI arguments",
+        json_schema_extra={"caep_unknown_args": True},
+    )
+
+
+config = caep.load(
+    Config,
+    "CAEP Example",
+    unknown_config_key="ignore",  # enables parse_known_args
+)
+```
+
+In this mode, unknown CLI tokens (e.g. `["--other", "value"]`) are stored in
+`config.unknown` while known arguments are parsed as usual. Only one field can be
+marked as unknown-argument.
 
 # Pydantic field types
 

--- a/caep/config.py
+++ b/caep/config.py
@@ -44,7 +44,7 @@ Example:
 >>> parser.add_argument('--number', type=int, default=1)
 >>> parser.add_argument('--bool', action='store_true')
 >>> parser.add_argument('--str-arg')
->>> args = config.handle_args(
+>>> args, _ = config.handle_args(
         parser,
         <CONFIG_ID>,
         <CONFIG_FILE_NAME>,
@@ -302,7 +302,7 @@ def handle_args(
     opts: Optional[list[str]] = None,
     unknown_config_key: Literal["ignore", "warning", "error"] = "warning",
     return_unknown_args: bool = False,
-) -> argparse.Namespace | tuple[argparse.Namespace, list[str]]:
+) -> tuple[argparse.Namespace, list[str]]:
     """
     Parse and set up the command line argument system above
     with config file parsing.
@@ -360,7 +360,4 @@ def handle_args(
         section_name,
     )
 
-    if return_unknown_args:
-        return args, unknown_args
-
-    return args
+    return args, unknown_args

--- a/caep/config.py
+++ b/caep/config.py
@@ -301,7 +301,8 @@ def handle_args(
     section_name: Optional[str],
     opts: Optional[list[str]] = None,
     unknown_config_key: Literal["ignore", "warning", "error"] = "warning",
-) -> argparse.Namespace:
+    return_unknown_args: bool = False,
+) -> argparse.Namespace | tuple[argparse.Namespace, list[str]]:
     """
     Parse and set up the command line argument system above
     with config file parsing.
@@ -315,6 +316,9 @@ def handle_args(
 
     ArgumentError is raised if some but not all of config_id, config_name and
     section_name are specified.
+
+    If `return_unknown_args` is True, the return value is a tuple of the parsed
+    Namespace and the list of unknown CLI tokens from `parse_known_args`.
     """
 
     config_opts = [config_id, config_name]
@@ -340,8 +344,10 @@ def handle_args(
 
     parser.set_defaults(**all_defaults(parser, config))
 
+    unknown_args: list[str] = []
+
     if unknown_config_key == "ignore":
-        args = parser.parse_known_args(remainder_argv)[0]
+        args, unknown_args = parser.parse_known_args(remainder_argv)
     else:
         args = parser.parse_args(remainder_argv)
 
@@ -353,5 +359,8 @@ def handle_args(
         config_name,
         section_name,
     )
+
+    if return_unknown_args:
+        return args, unknown_args
 
     return args

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "caep"
-version = "1.5.3"
+version = "1.6.0"
 description = "Config Argument Env Parser (CAEP)"
 authors = [{ name = "mnemonic", email = "opensource@mnemonic.no" }]
 requires-python = ">=3.9"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,7 +28,7 @@ def test_argparse_only() -> None:
 
     commandline = "--str-arg test".split()
 
-    args = config.handle_args(
+    args, _ = config.handle_args(
         parser, "actworkers", "actworkers.ini", "test", opts=commandline
     )
 
@@ -43,7 +43,7 @@ def test_argparse_ini() -> None:
 
     commandline = f"--config {INI_TEST_FILE}".split()
 
-    args = config.handle_args(
+    args, _ = config.handle_args(
         parser,
         "actworkers",
         "actworkers.ini",
@@ -71,7 +71,9 @@ def test_argparse_env() -> None:
     for key, value in env.items():
         os.environ[key] = str(value)
 
-    args = config.handle_args(parser, "actworkers", "actworkers.ini", "test", opts=[])
+    args, _ = config.handle_args(
+        parser, "actworkers", "actworkers.ini", "test", opts=[]
+    )
 
     assert args.number == 4
     assert args.str_arg == "from env"
@@ -102,7 +104,7 @@ def test_argparse_env_ini() -> None:
         f"--config {INI_TEST_FILE} --str-arg cmdline --unknown-arg 2 other-arg".split()
     )
 
-    args = config.handle_args(
+    args, _ = config.handle_args(
         parser,
         "actworkers",
         "actworkers.ini",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -516,7 +516,7 @@ def test_unknown_arguments2() -> None:
     )
 
     assert config.text == "hello"
-    assert config.unknown == ["--other", "flags", "value1", "value2"]
+    assert config.unknown == ["--other", "flag", "value1", "value2"]
 
 
 def test_multiple_unknown_argument_fields_not_allowed() -> None:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -130,6 +130,29 @@ class ArgCombined(Arg1, Arg2, Arg3):
     pass
 
 
+class UnknownArgsConfig(BaseModel):
+    text: str = Field(description="Required String Argument")
+    unknown: list[str] = Field(
+        default_factory=list,
+        description="Unknown CLI arguments",
+        json_schema_extra={"caep_unknown_args": True},
+    )
+
+
+class DoubleUnknownArgs(BaseModel):
+    primary: str = Field(description="Primary argument")
+    first_unknown: list[str] = Field(
+        default_factory=list,
+        description="First",
+        json_schema_extra={"caep_unknown_args": True},
+    )
+    second_unknown: list[str] = Field(
+        default_factory=list,
+        description="Second",
+        json_schema_extra={"caep_unknown_args": True},
+    )
+
+
 def parse_args(
     model: type[caep.schema.BaseModelType],
     commandline: Optional[list[str]] = None,
@@ -468,3 +491,40 @@ def test_split_dict() -> None:
 
     with pytest.raises(FieldError):
         split_dict("a,b", DictInfo(dict_type=str))
+
+
+def test_unknown_arguments1() -> None:
+    commandline = shlex.split("--text hello --other flag --third 3")
+
+    config = parse_args(
+        UnknownArgsConfig,
+        commandline,
+        unknown_config_key="ignore",
+    )
+
+    assert config.text == "hello"
+    assert config.unknown == ["--other", "flag", "--third", "3"]
+
+
+def test_unknown_arguments2() -> None:
+    commandline = shlex.split("--text hello --other flag value1 value2")
+
+    config = parse_args(
+        UnknownArgsConfig,
+        commandline,
+        unknown_config_key="ignore",
+    )
+
+    assert config.text == "hello"
+    assert config.unknown == ["--other", "flags", "value1", "value2"]
+
+
+def test_multiple_unknown_argument_fields_not_allowed() -> None:
+    commandline = shlex.split("--primary value --extra something")
+
+    with pytest.raises(FieldError):
+        parse_args(
+            DoubleUnknownArgs,
+            commandline,
+            unknown_config_key="ignore",
+        )


### PR DESCRIPTION
Add support to keep unknown cli arguments.

See example documented in README.